### PR TITLE
Potential fix for code scanning alert no. 6: Flask app is run in debug mode

### DIFF
--- a/clone.py
+++ b/clone.py
@@ -111,4 +111,6 @@ def screenshot():
 
 if __name__ == '__main__':
     # Use a production server like Gunicorn instead of the built-in development server
-    app.run(debug=True, use_reloader=False)
+    import os
+    debug_mode = os.getenv('FLASK_ENV') == 'development'
+    app.run(debug=debug_mode, use_reloader=False)


### PR DESCRIPTION
Potential fix for [https://github.com/mayowa-kalejaiye/MirrorWeb/security/code-scanning/6](https://github.com/mayowa-kalejaiye/MirrorWeb/security/code-scanning/6)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can easily switch between development and production environments without changing the code.

1. Modify the `app.run` call to use the `FLASK_ENV` environment variable to determine whether to run in debug mode.
2. Update the code to read the `FLASK_ENV` environment variable and set the `debug` parameter accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
